### PR TITLE
Add Support for PHP 8.3 / 8.2

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['7.4', '8.0', '8.1']
+        version: ['7.4', '8.0', '8.1', '8.3']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['7.4', '8.0', '8.1', '8.3']
+        version: ['7.4', '8.0', '8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout code

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,0 +1,35 @@
+FROM kooldev/php:8.2
+
+# make Composer global vendor/bin available through PATH
+RUN echo "export PATH=\$PATH:\/root\/.composer\/vendor\/bin:\/phars/" | tee -a /etc/profile
+
+# install dependencies (ast)
+RUN apk add --no-cache --virtual .build-deps $PHPIZE_DEPS \
+    && pecl install ast \
+    && echo 'extension=ast.so' >> /usr/local/etc/php/php.ini \
+    && docker-php-ext-enable xdebug \
+    && apk del .build-deps \
+    && rm -rf /var/cache/apk/* /tmp/*
+
+# install QA tools
+RUN \
+    # install and set up QA tools from Composer
+    composer global require squizlabs/php_codesniffer \
+        phpstan/phpstan \
+        friendsofphp/php-cs-fixer \
+        phan/phan \
+    # download PHAR and make them executable
+    && mkdir /phars \
+    && curl -Lf https://phpmd.org/static/latest/phpmd.phar -o /phars/phpmd \
+    && curl -Lf https://github.com/fabpot/local-php-security-checker/releases/download/v1.0.0/local-php-security-checker_1.0.0_linux_amd64 -o /phars/local-php-security-checker \
+    && curl -Lf https://phar.phpunit.de/phpcpd.phar -o /phars/phpcpd \
+    && curl -Lf https://phar.phpunit.de/phpunit-9.5.phar -o /phars/phpunit \
+    && chmod +x /phars/* \
+    # post-install tools settings
+    && /phars/local-php-security-checker --update-cache
+
+ADD entrypoint.sh /kool/entrypoint.sh
+RUN chmod +x /kool/entrypoint.sh
+
+ENTRYPOINT [ "/kool/entrypoint.sh" ]
+CMD [ "composer", "--version" ]

--- a/8.2/entrypoint.sh
+++ b/8.2/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /etc/profile
+
+exec "$@"

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,0 +1,35 @@
+FROM kooldev/php:8.3
+
+# make Composer global vendor/bin available through PATH
+RUN echo "export PATH=\$PATH:\/root\/.composer\/vendor\/bin:\/phars/" | tee -a /etc/profile
+
+# install dependencies (ast)
+RUN apk add --no-cache --virtual .build-deps $PHPIZE_DEPS \
+    && pecl install ast \
+    && echo 'extension=ast.so' >> /usr/local/etc/php/php.ini \
+    && docker-php-ext-enable xdebug \
+    && apk del .build-deps \
+    && rm -rf /var/cache/apk/* /tmp/*
+
+# install QA tools
+RUN \
+    # install and set up QA tools from Composer
+    composer global require squizlabs/php_codesniffer \
+        phpstan/phpstan \
+        friendsofphp/php-cs-fixer \
+        phan/phan \
+    # download PHAR and make them executable
+    && mkdir /phars \
+    && curl -Lf https://phpmd.org/static/latest/phpmd.phar -o /phars/phpmd \
+    && curl -Lf https://github.com/fabpot/local-php-security-checker/releases/download/v1.0.0/local-php-security-checker_1.0.0_linux_amd64 -o /phars/local-php-security-checker \
+    && curl -Lf https://phar.phpunit.de/phpcpd.phar -o /phars/phpcpd \
+    && curl -Lf https://phar.phpunit.de/phpunit-9.5.phar -o /phars/phpunit \
+    && chmod +x /phars/* \
+    # post-install tools settings
+    && /phars/local-php-security-checker --update-cache
+
+ADD entrypoint.sh /kool/entrypoint.sh
+RUN chmod +x /kool/entrypoint.sh
+
+ENTRYPOINT [ "/kool/entrypoint.sh" ]
+CMD [ "composer", "--version" ]

--- a/8.3/entrypoint.sh
+++ b/8.3/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /etc/profile
+
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ docker run --rm --init -it -v $(pwd):/app -w /app kooldev/phpqa:7.4
 
 The image built is [`kooldev/phpqa`](https://hub.docker.com/r/kooldev/phpqa/tags?page=1&ordering=last_updated) with tags:
 
+- [**`8.3`**](https://github.com/kool-dev/docker-phpqa/blob/main/8.3/Dockerfile)
 - [**`8.1`**](https://github.com/kool-dev/docker-phpqa/blob/main/8.1/Dockerfile)
 - [**`8.0`**](https://github.com/kool-dev/docker-phpqa/blob/main/8.0/Dockerfile)
 - [**`7.4`**](https://github.com/kool-dev/docker-phpqa/blob/main/7.4/Dockerfile)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ docker run --rm --init -it -v $(pwd):/app -w /app kooldev/phpqa:7.4
 The image built is [`kooldev/phpqa`](https://hub.docker.com/r/kooldev/phpqa/tags?page=1&ordering=last_updated) with tags:
 
 - [**`8.3`**](https://github.com/kool-dev/docker-phpqa/blob/main/8.3/Dockerfile)
+- [**`8.2`**](https://github.com/kool-dev/docker-phpqa/blob/main/8.2/Dockerfile)
 - [**`8.1`**](https://github.com/kool-dev/docker-phpqa/blob/main/8.1/Dockerfile)
 - [**`8.0`**](https://github.com/kool-dev/docker-phpqa/blob/main/8.0/Dockerfile)
 - [**`7.4`**](https://github.com/kool-dev/docker-phpqa/blob/main/7.4/Dockerfile)

--- a/fwd-template.json
+++ b/fwd-template.json
@@ -45,6 +45,36 @@
                     "path": "template/entrypoint"
                 }
             ]
+        },
+        {
+            "name": "8.2",
+            "data": {
+                "from": "kooldev/php:8.2"
+            },
+            "files": [
+                {
+                    "name": "Dockerfile",
+                    "path": "template/Dockerfile"
+                }, {
+                    "name": "entrypoint.sh",
+                    "path": "template/entrypoint"
+                }
+            ]
+        },
+        {
+            "name": "8.3",
+            "data": {
+                "from": "kooldev/php:8.3"
+            },
+            "files": [
+                {
+                    "name": "Dockerfile",
+                    "path": "template/Dockerfile"
+                }, {
+                    "name": "entrypoint.sh",
+                    "path": "template/entrypoint"
+                }
+            ]
         }
     ]
 }

--- a/kool.yml
+++ b/kool.yml
@@ -9,5 +9,7 @@ scripts:
     - docker build --pull -t kooldev/phpqa:8.0 8.0
     # PHP 8.1
     - docker build --pull -t kooldev/phpqa:8.1 8.1
+    # PHP 8.2
+    - docker build --pull -t kooldev/phpqa:8.2 8.2
     # PHP 8.3
     - docker build --pull -t kooldev/phpqa:8.3 8.3

--- a/kool.yml
+++ b/kool.yml
@@ -9,3 +9,5 @@ scripts:
     - docker build --pull -t kooldev/phpqa:8.0 8.0
     # PHP 8.1
     - docker build --pull -t kooldev/phpqa:8.1 8.1
+    # PHP 8.3
+    - docker build --pull -t kooldev/phpqa:8.3 8.3


### PR DESCRIPTION
@dbpolito @fabriciojs - submitting this PR to add support for PHP 8.3 to `docker-phpqa`. Just starting a new 8.3 project and would love to use Kool and this version with CS Fixer. You already have the [PHP 8.3 image](https://hub.docker.com/layers/kooldev/php/8.3/images/sha256-ed5b529424f0067596113e49c4b97dc4818ad3b85e606c1cd1b19dcb3e0885b3?context=explore). I believe the only change from prior versions is to update the Dockerfile with `FROM kooldev/php:8.3` (everything else is exactly the same). And, after merging, do you need to create a new Docker Hub image for 8.3 here > https://hub.docker.com/r/kooldev/phpqa/tags?